### PR TITLE
Fix: werewolf lvl 10 quest

### DIFF
--- a/src/main/kotlin/dev/sterner/witchery/features/affliction/werewolf/WerewolfLeveling.kt
+++ b/src/main/kotlin/dev/sterner/witchery/features/affliction/werewolf/WerewolfLeveling.kt
@@ -181,7 +181,11 @@ object WerewolfLeveling {
             return
         }
 
-        increaseWerewolfLevel(player)
+        val newData = AfflictionPlayerAttachment.smartUpdate(player, sync = true) {
+            withSpreadLycanthropy(true)
+        }
+
+        checkAndLevelUp(player, newData)
     }
 
     //To go from Level 3 -> 4


### PR DESCRIPTION
For some reason this one tried to directly level up without setting the SpreadLycantthropy flag and failed. Made it work like the other quests.