### PR TITLE
Fix: suspicios dirt not behaving like dirt

### DIFF
--- a/src/main/kotlin/dev/sterner/witchery/core/registry/WitcheryBlocks.kt
+++ b/src/main/kotlin/dev/sterner/witchery/core/registry/WitcheryBlocks.kt
@@ -1223,7 +1223,7 @@ object WitcheryBlocks {
                 Blocks.COARSE_DIRT,
                 SoundEvents.BRUSH_GRAVEL,
                 SoundEvents.BRUSH_GRAVEL_COMPLETED,
-                Properties.of()
+                Properties.ofFullCopy(Blocks.DIRT)
                     .sound(SoundType.SOUL_SAND)
             )
         }


### PR DESCRIPTION
I think not dropping anything is intentional, but insta breaking with bare hands doesnt sound so.
I mentioned dirt in #106, but https://github.com/mrsterner/witchery/commit/632e13213bb31a2bb576e5e518a5026771e962d0 fixed only gravestones